### PR TITLE
State Go Build Pulse manual delivery window

### DIFF
--- a/products/go-build-pulse/index.html
+++ b/products/go-build-pulse/index.html
@@ -31,6 +31,7 @@
           <button class="btn" id="sampleBtn">Load Sample</button>
           <a class="btn gold" href="https://buymeacoffee.com/kgninja" target="_blank" rel="noreferrer">Pay $9 via BuyMeACoffee</a>
           <a class="btn secondary" href="mailto:fuwafuwow@gmail.com?subject=Go%20Build%20Pulse%20manual%20review&body=I%20paid%20%249%20via%20BuyMeACoffee.%0AReceipt%20or%20payment%20reference%3A%0AReply%20email%3A%0ARepo%20URL%3A%0ABuild%20logs%20with%20secrets%20removed%3A%0AGoal%3A">Send receipt for a tailored fix review</a>
+          <p class="note">Manual delivery: a tailored build-fix plan within 24 hours after payment confirmation.</p>
           <a class="btn" href="https://agentos-revenue-cloudflare.fuwafuwow.workers.dev/buy" target="_blank" rel="noreferrer">AI agent checkout: verified x402 diagnostic API</a>
         </div>
       </div>


### PR DESCRIPTION
Adds the 24-hour fulfillment target to the existing manual paid-review intake. README/UI-only change; no payment logic changed.